### PR TITLE
added object splitter to tar_map()

### DIFF
--- a/1_fetch/src/get_site_data.R
+++ b/1_fetch/src/get_site_data.R
@@ -1,7 +1,7 @@
 # download data for each site
 # packages needed: tidyverse, dataRetrieval
-get_site_data <- function(sites_info, state, parameter) {
-  site_info <- filter(sites_info, state_cd == state)
+get_site_data <- function(site_info, state, parameter) {
+
   message(sprintf('  Retrieving data for %s-%s', state, state))
 
   # simulate an unreliable web service or internet connection by causing random failures

--- a/_targets.R
+++ b/_targets.R
@@ -2,6 +2,7 @@
 library(targets)
 library(tarchetypes)
 library(tibble)
+library(tidyverse)
 
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr", "rnaturalearth", "cowplot"))
@@ -12,7 +13,7 @@ source("1_fetch/src/get_site_data.R")
 source("3_visualize/src/map_sites.R")
 
 # Configuration
-states <- c('WI','MN','MI', 'IL')
+states <- c('WI','MN','MI', 'IL', 'IN', 'IA')
 parameter <- c('00060')
 
 # Targets
@@ -25,9 +26,11 @@ list(
   # TODO: PULL SITE DATA HERE
   tar_map(
     values = tibble(state_abb = states),
+    tar_target(nwis_inventory,
+               oldest_active_sites %>% filter(state_cd == state_abb)),
     tar_target(
       nwis_data,
-      get_site_data(sites_info = oldest_active_sites,
+      get_site_data(site_info = nwis_inventory,
                     state = state_abb,
                     parameter = parameter))
   ),


### PR DESCRIPTION
I added an object splitter to the `tar_map()` function that *should* increase the efficiency of my pipeline so that data doesn't get reloaded each time I `tar_make()` with additional states. However, after adding Indiana and Iowa to the pipeline, because the `oldest_active_sites` target was updated, all the downstream `nwis_data_xx` rebuilt, including states that had already been built (e.g., MI). 

<img width="704" alt="image" src="https://user-images.githubusercontent.com/19958841/174831264-a41e3003-8f62-4235-a5d2-f26f58f05a77.png">

